### PR TITLE
Support custom config file name and publishdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ $ git push heroku master
 $ heroku open
 ```
 
+Environment Variables
+===
+
+To use a custom config file name or `publishdir` you can use these environment variables:
+
+```bash
+$ heroku config:set HUGOCONFIG="config_de.toml"
+```
+
+```bash
+$ heroku config:set HUGOPATH="public/custom"
+```
+
+
 Legacy Compatibility
 ===
 

--- a/bin/compile
+++ b/bin/compile
@@ -41,8 +41,15 @@ if [ -e $BUILD_DIR/.hugotheme ]; then
   git clone $THEME_URL
 fi
 
+# Fetch config file
+if [ -z "$HUGOCONFIG" ]; then
+	CONFIG_FILE="`ls $BUILD_DIR | grep config | head -n1`"
+else
+	CONFIG_FILE="$HUGOCONFIG"
+fi
+
 # Build the site
-echo "\n-----> Building the site"
+echo "\n-----> Building the site with config file $CONFIG_FILE"
 cd $BUILD_DIR
 mkdir -p static | indent
-./hugo | indent
+./hugo --config="$CONFIG_FILE" | indent

--- a/bin/detect
+++ b/bin/detect
@@ -2,9 +2,13 @@
 
 BUILD_DIR=$1
 
-CONFIG_FILE="`ls $BUILD_DIR | grep config`"
+if [ -z "$HUGOCONFIG" ]; then
+	CONFIG_FILE="`ls $BUILD_DIR | grep config | head -n1`"
+else
+	CONFIG_FILE="$HUGOCONFIG"
+fi
 
-if [ -z $CONFIG_FILE ]; then
+if [ -z "$CONFIG_FILE" ]; then
   echo "\n-----> Hugo expects to find a config file in the root of the source directory! please include a config.toml, config.yaml or config.json file"
   exit 1
 fi

--- a/bin/release
+++ b/bin/release
@@ -1,7 +1,10 @@
 #!/bin/sh
+if [ -z "$HUGOPATH" ]; then
+	HUGOPATH="public"
+fi
 
 cat << EOF
 ---
 default_process_types:
-  web: "cd public && python -m SimpleHTTPServer \$PORT"
+  web: "cd \$HUGOPATH && python -m SimpleHTTPServer \$PORT"
 EOF


### PR DESCRIPTION
This pull request adds an option to use a different config file name and/or publishdir. 

You can set your heroku environment variables with

``` bash
$ heroku config:set HUGOCONFIG="config_de.toml"
```

and

``` bash
$ heroku config:set HUGOPATH="public/custom"
```
