### PR TITLE
Fix extract file names

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -16,7 +16,7 @@ CACHE_DIR=$2
 VERSION="0.17"
 
 # Hugo URL ( download from GH builds )
-ARCHIVE_NAME=hugo_${VERSION}_Linux_64bit
+ARCHIVE_NAME=hugo_${VERSION}_Linux-64bit
 FILE_NAME=${ARCHIVE_NAME}.tar.gz
 HUGO_PACKAGE=https://github.com/spf13/hugo/releases/download/v${VERSION}/${FILE_NAME}
 

--- a/bin/compile
+++ b/bin/compile
@@ -17,6 +17,7 @@ VERSION="0.17"
 
 # Hugo URL ( download from GH builds )
 ARCHIVE_NAME=hugo_${VERSION}_Linux-64bit
+EXTRACT_NAME=hugo_${VERSION}_linux_amd64
 FILE_NAME=${ARCHIVE_NAME}.tar.gz
 HUGO_PACKAGE=https://github.com/spf13/hugo/releases/download/v${VERSION}/${FILE_NAME}
 
@@ -29,9 +30,9 @@ fi
 
 # Extract the binary in the working directory
 echo "\n-----> Extracting Hugo ${VERSION} binaries to ${BUILD_DIR}/vendor/hugo"
-mkdir -p $CACHE_DIR/$ARCHIVE_NAME | indent
+mkdir -p $CACHE_DIR/$EXTRACT_NAME | indent
 tar -zxvf $CACHE_DIR/$FILE_NAME -C $CACHE_DIR | indent
-mv $CACHE_DIR/$ARCHIVE_NAME/$ARCHIVE_NAME $BUILD_DIR/hugo | indent
+mv $CACHE_DIR/$EXTRACT_NAME/$EXTRACT_NAME $BUILD_DIR/hugo | indent
 
 # Fetch a theme specified in the .hugotheme file
 if [ -e $BUILD_DIR/.hugotheme ]; then


### PR DESCRIPTION
relevant issue: #16 

Hugo latest release has changed the release package file names,
but extract file names does not changed. This may be a hugo's problem.

This is just a quick note.

```
$ tar zxvf hugo_0.17_Linux-64bit.tar.gz
x hugo_0.17_linux_amd64/hugo_0.17_linux_amd64
x hugo_0.17_linux_amd64/README.md
x hugo_0.17_linux_amd64/LICENSE.md
```
