### PR TITLE
Use a different name for the hugo executable

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -16,8 +16,9 @@ CACHE_DIR=$2
 VERSION="0.17"
 
 # Hugo URL ( download from GH builds )
-ARCHIVE_NAME=hugo_${VERSION}_Linux_64bit
+ARCHIVE_NAME=hugo_${VERSION}_Linux-64bit
 FILE_NAME=${ARCHIVE_NAME}.tar.gz
+EXECUTABLE_NAME=hugo_${VERSION}_linux_amd64
 HUGO_PACKAGE=https://github.com/spf13/hugo/releases/download/v${VERSION}/${FILE_NAME}
 
 # Store the hugo package in the cache_dir ( persistent across builds )
@@ -29,9 +30,9 @@ fi
 
 # Extract the binary in the working directory
 echo "\n-----> Extracting Hugo ${VERSION} binaries to ${BUILD_DIR}/vendor/hugo"
-mkdir -p $CACHE_DIR/$ARCHIVE_NAME | indent
+mkdir -p $CACHE_DIR/$EXECUTABLE_NAME | indent
 tar -zxvf $CACHE_DIR/$FILE_NAME -C $CACHE_DIR | indent
-mv $CACHE_DIR/$ARCHIVE_NAME/$ARCHIVE_NAME $BUILD_DIR/hugo | indent
+mv $CACHE_DIR/$EXECUTABLE_NAME/$EXECUTABLE_NAME $BUILD_DIR/hugo | indent
 
 # Fetch a theme specified in the .hugotheme file
 if [ -e $BUILD_DIR/.hugotheme ]; then


### PR DESCRIPTION
After the v017 release the hugo executable and the file path are
different, this commit introduces a new variable to handle that
situatioUse a different name for the hugo executable

After the v017 release the hugo executable and the file path are
different, this commit introduces a new variable to handle that
situation

Fixes #16 
