### PR TITLE
Add option to get hugo to publish draft content when building

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Optionally, define a `HUGO_VERSION` Config Var to specify the Hugo version you w
 ```bash
 $ heroku config:set HUGO_VERSION=0.25
 ```
+Or set a `HUGO_BUILD_DRAFTS` Config Var to `TRUE` to get hugo to publish draft content.
+
+```bash
+$ heroku config:set HUGO_BUILD_DRAFTS=TRUE
+```
 
 Then simply git push to heroku and open your application!
 

--- a/bin/compile
+++ b/bin/compile
@@ -50,8 +50,20 @@ if [ -e $BUILD_DIR/.hugotheme ]; then
   git clone $THEME_URL
 fi
 
+# attempt to extract the HUGO_BUILD_DRAFTS parameter form the Heroku configuration vars, fall back to FALSE if unavailable
+if [ -d "$ENV_DIR" -a -e "$ENV_DIR/HUGO_BUILD_DRAFTS" ]; then
+  HUGO_BUILD_DRAFTS=$(cat "$ENV_DIR/HUGO_BUILD_DRAFTS")
+  echo "\n-----> HUGO BUILD DRAFTS Enabled. Draft posts will be published."
+else
+  HUGO_BUILD_DRAFTS=FALSE
+fi
+
 # Build the site
 echo "\n-----> Building the site"
 cd $BUILD_DIR
 mkdir -p static | indent
-./hugo | indent
+if [ $HUGO_BUILD_DRAFTS ]; then
+  ./hugo --buildDrafts | indent
+else
+  ./hugo | indent
+fi


### PR DESCRIPTION
You can now set `HUGO_PUBLISH_DRAFTS` to `TRUE` to get hugo to publish draft content.