### PR TITLE
update to v0.31.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ heroku buildpacks:set BUILDPACK_URL="https://github.com/roperzh/heroku-buildpa
 Optionally, define a `HUGO_VERSION` Config Var to specify the Hugo version you wish to use:
 
 ```bash
-$ heroku config:set HUGO_VERSION=0.25
+$ heroku config:set HUGO_VERSION=0.31.1
 ```
 
 Then simply git push to heroku and open your application!

--- a/bin/compile
+++ b/bin/compile
@@ -14,7 +14,7 @@ CACHE_DIR=$2
 ENV_DIR=$3
 
 # Default Hugo version
-DEFAULT_HUGO_VERSION="0.26"
+DEFAULT_HUGO_VERSION="0.31.1"
 
 # attempt to extract the HUGO_VERSION parameter form the Heroku configuration vars, fall back to the default version if unavailable
 if [ -d "$ENV_DIR" -a -e "$ENV_DIR/HUGO_VERSION" ]; then
@@ -27,7 +27,7 @@ fi
 # Hugo URL ( download from GH builds )
 RELEASE_NAME=hugo_${HUGO_VERSION}_Linux-64bit
 FILE_NAME=${RELEASE_NAME}.tar.gz
-HUGO_PACKAGE=https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/${FILE_NAME}
+HUGO_PACKAGE=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${FILE_NAME}
 
 # Store the hugo package in the cache_dir ( persistent across builds )
 mkdir -p $CACHE_DIR


### PR DESCRIPTION
This PR will also reflect the update of the Hugo repository URL from https://github.com/spf13/hugo/ to https://github.com/gohugoio/hugo/.