### PR TITLE
Support for using “extended_” versions of Hugo

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -27,7 +27,8 @@ fi
 # Hugo URL ( download from GH builds )
 RELEASE_NAME=hugo_${HUGO_VERSION}_Linux-64bit
 FILE_NAME=${RELEASE_NAME}.tar.gz
-HUGO_PACKAGE=https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/${FILE_NAME}
+TAG_NAME=${HUGO_VERSION#extended_}
+HUGO_PACKAGE=https://github.com/spf13/hugo/releases/download/v${TAG_NAME}/${FILE_NAME}
 
 # Store the hugo package in the cache_dir ( persistent across builds )
 mkdir -p $CACHE_DIR


### PR DESCRIPTION
The latest release of Hugo has two variations "0.43" and "extended_0.43" with SASS/SCSS support.  This PR allows the user to specify HUGO_VERSION to "extended_0.43" to download the extended version.

See https://github.com/gohugoio/hugo/releases/tag/v0.43 for more details on the "extended" release